### PR TITLE
ci: Fix presigned url formation issue

### DIFF
--- a/.github/actions/aws-s3-exchanger/action.yml
+++ b/.github/actions/aws-s3-exchanger/action.yml
@@ -38,15 +38,15 @@ runs:
             echo "::group::$(printf '__________ %-100s' 'Process' | tr ' ' _)"
             echo "Uploading file to S3 bucket..."
             aws s3 cp "${{ inputs.local_file }}" s3://${{ inputs.s3_bucket }}/${{ inputs.location }}${{ env.UPLOAD_LOCATION }}
-            echo "Uploaded ${{ inputs.local_file }} to s3://${{ inputs.s3_bucket }}/${{ inputs.location }}/${{ env.UPLOAD_LOCATION }}"
+            echo "Uploaded ${{ inputs.local_file }} to s3://${{ inputs.s3_bucket }}/${{ inputs.location }}${{ env.UPLOAD_LOCATION }}"
             echo "::endgroup::"
             echo "Creating Pre-signed URL for ${{ inputs.local_file }}..."
             filename="$(basename "${{ inputs.local_file }}")"
             echo "Filename: $filename"
-            presigned_url="$(aws s3 presign s3://${{ inputs.s3_bucket }}/${{ inputs.location }}/${{ env.UPLOAD_LOCATION }}$filename --expires-in 3600)"
+            presigned_url="$(aws s3 presign s3://${{ inputs.s3_bucket }}/${{ inputs.location }}${{ env.UPLOAD_LOCATION }}$filename --expires-in 3600)"
             echo "Pre-signed URL: $presigned_url"
             # write the url in a text file
-            echo ${presigned_url} > ${{ github.workspace }}/presigned_url.txt
+            echo "${presigned_url}" > ${{ github.workspace }}/presigned_url.txt
             ;;
           download)
             #Download The required file from s3


### PR DESCRIPTION
This commit fixes an issue with the formation of a pre-signed URL in the AWS S3 file exchange action. The key changes include:

- Correct URL path formation by adjusting how ${{ env.UPLOAD_LOCATION }} is concatenated.
- Ensure consistency in writing the pre-signed URL to a file.
- Standardize formatting for better readability and reliability.