### PR TITLE
configure AWS runner for Armor

### DIFF
--- a/.github/workflows/armor.yml
+++ b/.github/workflows/armor.yml
@@ -28,7 +28,9 @@ permissions:
 
 jobs:
   RUN-ARMOR:
-    runs-on: ubuntu-22.04
+    runs-on:
+      group: GHA-AudioReach-SelfHosted-RG
+      labels: [ self-hosted, audior-prd-u2204-x64-large-od-ephem ]
     steps:
       - uses: actions/checkout@v4
       - name: Set event variables


### PR DESCRIPTION
Update run_armor workflow to use AWS self-hosted runners. Enable
uploading artifacts generated during RUN-ARMOR workflow to an S3
location for secure storage and further processing.