### PR TITLE
Diag enable

### DIFF
--- a/acdb/ats/transports/diag/linux/audtp/inc/audtp.h
+++ b/acdb/ats/transports/diag/linux/audtp/inc/audtp.h
@@ -25,10 +25,6 @@
       --------------------
  */
 
-/** Definitions for char_t, word, etc. */
-#ifndef ATS_USES_DUMMY_DIAG
-#include "comdef.h"
-#endif
 #include "audtpi.h"
 #include "diagcmd.h"
 #include "diagpkt.h"

--- a/ar_osal/Makefile.am
+++ b/ar_osal/Makefile.am
@@ -58,6 +58,9 @@ else
 osal_c_sources += ./src/linux/qcom/ar_osal_log_pkt_op.c
 endif
 
+if LIBDIAG_HEADERS
+AM_CFLAGS += -DUSE_LIBDIAG_HEADERS
+endif
 
 if ARGS_USE_SYSLOG
 AM_CFLAGS += -DAR_OSAL_USE_SYSLOG
@@ -86,7 +89,7 @@ endif
 if USE_DUMMY_DIAG
 #dummy diag, do not link real diag libs
 else
-libar_osal_la_LIBADD += -llog -ldiag
+libar_osal_la_LIBADD += -ldiag
 endif
 
 if USE_G_STR_FUNC

--- a/ar_osal/src/linux/qcom/ar_osal_log_pkt_op.c
+++ b/ar_osal/src/linux/qcom/ar_osal_log_pkt_op.c
@@ -11,7 +11,11 @@
 #include "ar_osal_log_pkt_op.h"
 #include "ar_osal_error.h"
 #include "ar_osal_log.h"
+#ifndef USE_LIBDIAG_HEADERS
 #include "comdef.h"
+#else
+#include "diag_comdef.h"
+#endif
 #include "diag_lsm.h"
 #include "log.h"
 

--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,12 @@ AC_ARG_WITH([audio_dma_support],
     [with_audio_dma_support=no])
 AM_CONDITIONAL([AUDIO_DMA_SUPPORT], [test "x${with_audio_dma_support}" = "xyes"])
 
+AC_ARG_WITH([libdiag_headers],
+    AS_HELP_STRING([--with-libdiag_headers],[use libdiag headers only (default is no)]),
+    [with_libdiag_headers=$withval],
+    [with_libdiag_headers=no])
+AM_CONDITIONAL([LIBDIAG_HEADERS], [test "x${with_libdiag_headers}" = "xyes"])
+
 AC_ARG_WITH([libion],
     AS_HELP_STRING([use libion (default is no)]),
     [with_libion=$withval],


### PR DESCRIPTION
Remove unused comdef.h include from audtp.h
Use DIAG-specific headers when DIAG support is enabled by adding the USE_DIAG_HEADERS compile flag.
Drop -llog from linkage since it is no longer required.
Update CI build options to disable dummy_diag and enable DIAG for consistent builds.