### PR TITLE
Armor: Switch API compatibility checker to blocking mode

### DIFF
--- a/public_headers/config.yml
+++ b/public_headers/config.yml
@@ -3,7 +3,7 @@ project: https://github.com/AudioReach/audioreach-graphservices
 branches:
   master:
     modes:
-      non-blocking:
+      blocking:
         headers:
           - ar_osal/api/*.h
           - ar_util/api/*.h


### PR DESCRIPTION
Update config.yml in public_headers to enforce backward compatibility rules for public API headers.