### PR TITLE
args: Skip including subdir makefiles when using stub HAL

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -1,3 +1,4 @@
-ifeq ($(strip $(TARGET_USES_QCOM_MM_AUDIO)),true)
+ifneq ($(AUDIO_USE_STUB_HAL), true)
     include $(call all-subdir-makefiles)
 endif
+


### PR DESCRIPTION
Added a conditional check to prevent inclusion of all subdirectory makefiles if AUDIO_USE_STUB_HAL is set to true. This ensures that stub HAL builds do not pull in unnecessary components.