### PR TITLE
Makefile: spf: Add audio_if_api.h to API headers path.

### DIFF
--- a/spf/Makefile.am
+++ b/spf/Makefile.am
@@ -49,6 +49,7 @@ spf_sources = ./api/apm/apm_api.h \
                 ./api/modules/audio_hw_clk_api.h \
                 ./api/modules/audio_hw_dma_api.h \
                 ./api/modules/audio_hw_lpm_api.h \
+                ./api/modules/audio_if_api.h \
                 ./api/modules/celt_enc_api.h \
                 ./api/modules/codec_dma_api.h \
                 ./api/modules/codec_metadata_api.h \


### PR DESCRIPTION
Update Makefile to include audio_if_api.h api file path in ar-spfhdrs library to avoid missing header file error during audioreach-graphmgr compilation.