### PR TITLE
CI: Remove CFLAGS override and update configure header path

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -24,6 +24,6 @@ autoreconf -Wcross --verbose --install --force --exclude=autopoint
 autoconf --force
 
 # Run the configure script with the specified arguments
-./configure CFLAGS="-Wno-int-conversion" ${BUILD_ARGS} --with-sanitized-headers=${GITHUB_WORKSPACE}/install/sysroots/armv8-2a-poky-linux/usr/lib/module/build/include/uapi/sound/qcom
+./configure ${BUILD_ARGS}
 # make
 make DESTDIR=${GITHUB_WORKSPACE}/build install


### PR DESCRIPTION
Update the configure command by eliminating the unnecessary CFLAGS override to prevent redundant compiler flag suppression.