### PR TITLE
ARGS Upstream

### DIFF
--- a/gpr/datalinks/gpr_lx/src/gpr_lx.c
+++ b/gpr/datalinks/gpr_lx/src/gpr_lx.c
@@ -167,13 +167,11 @@ uint32_t put_buffer(gpr_dl_lx_port_t *dl_lx_port, void *buf)
 
     pthread_mutex_lock(&dl_lx_port->buff_list_lock);
     list_for_each_safe(item, temp_node, &dl_lx_port->buff_list) {
-        if (item != NULL) {
-            buffer_node = node_to_item(item, gpr_dl_lx_buf_t, node);
-            if (buffer_node && buffer_node->buffer == buf) {
-                AR_LOG_ERR(LOG_TAG,"%s:%d buffer already put error case", __func__, __LINE__);
-                pthread_mutex_unlock(&dl_lx_port->buff_list_lock);
-                return AR_EALREADY;
-            }
+        buffer_node = node_to_item(item, gpr_dl_lx_buf_t, node);
+        if (buffer_node && buffer_node->buffer == buf) {
+            AR_LOG_ERR(LOG_TAG,"%s:%d buffer already put error case", __func__, __LINE__);
+            pthread_mutex_unlock(&dl_lx_port->buff_list_lock);
+            return AR_EALREADY;
         }
     }
     buffer_node = (gpr_dl_lx_buf_t *)malloc(sizeof(gpr_dl_lx_buf_t));

--- a/gsl/src/gsl_global_persist_cal.c
+++ b/gsl/src/gsl_global_persist_cal.c
@@ -168,12 +168,6 @@ int32_t gsl_global_persist_cal_pool_remove(struct gsl_glbl_persist_cal *gpc)
 		--gpc->ref_cnt;
 
 	if (gpc->ref_cnt == 0) {
-		rc = gsl_shmem_free(&gpc->cal_data);
-		if (rc) {
-			GSL_ERR("gsl_shmem_free failed %d", rc);
-			goto exit;
-		}
-
 		rc = ar_list_delete(&gpc_pool.cal_list, &gpc->node);
 		if (rc) {
 			GSL_ERR("ar_list_delete failed %d", rc);

--- a/gsl/src/gsl_graph.c
+++ b/gsl/src/gsl_graph.c
@@ -5041,7 +5041,7 @@ int32_t gsl_graph_prepare_to_change_single_gkv(struct gsl_graph *graph,
 		}
 	}
 
-	if (!old_gkv_found) {
+	if (!old_gkv_found || old_node == NULL) {
 		rc = AR_ENOTEXIST;
 		goto exit;
 	}
@@ -5245,6 +5245,8 @@ int32_t gsl_graph_change_single_gkv(struct gsl_graph *graph,
 			break;
 		}
 	}
+	if (old_node == NULL)
+		return AR_EBADPARAM;
 
 	preserved_sgids = &old_node->rtc_cache.preserved_sgids;
 	pruned_plus_reopen_sg_conn =

--- a/gsl/src/gsl_rtc.c
+++ b/gsl/src/gsl_rtc.c
@@ -365,6 +365,13 @@ int32_t gsl_rtc_graph_set_persist_data(struct gsl_graph *graph,
 	sg = gsl_graph_get_sg_ptr(graph, params->sgid);
 	if (!sg)
 		return AR_EFAILED;
+
+	if (sg->num_proc_ids >
+		sizeof(sg->persist_cal_data_per_proc) /
+		sizeof(sg->persist_cal_data_per_proc[0])) {
+		GSL_ERR("num_proc_ids invalid: %d", sg->num_proc_ids);
+		return AR_EBADPARAM;
+	}
 	GSL_DBG("num procs per SG - %d", sg->num_proc_ids);
 	for (int persist_cal_idx = 0; persist_cal_idx < sg->num_proc_ids; persist_cal_idx++) {
 		if (sg->persist_cal_data_per_proc[persist_cal_idx].proc_id == params->proc_id) {

--- a/spf/Makefile.am
+++ b/spf/Makefile.am
@@ -64,6 +64,7 @@ spf_sources = ./api/apm/apm_api.h \
                 ./api/modules/data_logging_api.h \
                 ./api/modules/data_marker_api.h \
                 ./api/modules/detection_cmn_api.h \
+                ./api/modules/history_buffer_api.h \
                 ./api/modules/display_port_api.h \
                 ./api/modules/dls_api.h \
                 ./api/modules/dls_log_pkt_hdr_api.h \


### PR DESCRIPTION
Commits included: 

args: gpr: Remove redundant NULL check
args: Fix double free of global persist calibration data
args: Fix NULL dereference caused by invalid old_node pointer
args: Add bounds checking for persist_cal_idx to prevent out-of-bounds
spf: Add necessary headers support to build