### PR TITLE
dls: Add changes to enable DLS running on ADSP

### DIFF
--- a/acdb/ats/dls/common/src/ats_dls.c
+++ b/acdb/ats/dls/common/src/ats_dls.c
@@ -45,6 +45,8 @@ struct gsl_dls_buffer_pool_config_t buffer_pool_config;
 AtsBuffer dls_data_send_buffer;
 ar_osal_mutex_t buffer_ready_lock;
 ATS_DSL_TCPIP_SEND_CALLBACK ats_dls_tcpip_send_callback;
+ar_osal_thread_t thd_ready_buffer_routine;
+bool thd_ready_buffer_routine_active = true;
 
 #if defined(_DEVICE_SIM)
 int32_t gsl_dls_client_is_feature_supported()
@@ -270,9 +272,44 @@ int32_t ats_dls_get_log_data(
 	// ATS_MEM_CPY_SAFE(rsp_buf, sizeof(uint32_t), &rsp, sizeof(AtsDlsLogDataHeader));
 	*rsp_buf_bytes_filled += sizeof(AtsDlsLogDataHeader) + rsp.total_log_data_size;
 
-	ATS_DBG("return buffers to spf");
-	gsl_dls_client_return_used_buffers(&ready_buffer_index_list);
+	ATS_DBG("set used buffers to gsl");
+	gsl_dls_client_set_used_buffers(&ready_buffer_index_list);
 	ATS_DBG("done returning buffers to spf");
+
+	return status;
+}
+
+void ats_dls_ready_buffer_thd(void* params){
+
+	while(thd_ready_buffer_routine_active)
+	{
+	   //wait for signal and release ready buffers to dsp
+	   ATS_DBG("return buffers to spf");
+	   gsl_dls_client_return_used_buffers(NULL);
+	   ATS_DBG("done returning buffers to spf");
+	}
+}
+
+int32_t ats_dls_create_ready_buffer_thread()
+{
+	int32_t status = AR_EOK;
+	char_t* thd_name = "ATS_DLS_RDY_THD";
+	ar_osal_thread_attr_t thd_attr =
+    {
+        thd_name,
+        0xF4240,
+        0,
+    };
+
+    ar_osal_thread_start_routine r = \
+        (ar_osal_thread_start_routine)(ats_dls_ready_buffer_thd);
+
+    status = ar_osal_thread_create(&thd_ready_buffer_routine, &thd_attr, r, NULL);
+    if (AR_FAILED(status))
+    {
+        ATS_ERR("Error[%d]: Failed to create thread %s", status, thd_name);
+        return status;
+    }
 
 	return status;
 }
@@ -365,6 +402,7 @@ int32_t ats_dls_init(ATS_DSL_TCPIP_SEND_CALLBACK callback)
 	if (AR_FAILED(status))
 	{
 		ATS_ERR("Error[%d]: Failed initialize dls client", status);
+		goto destroy_lock;
 	}
 	//allocate buffer for storing dls log buffer
 
@@ -372,9 +410,15 @@ int32_t ats_dls_init(ATS_DSL_TCPIP_SEND_CALLBACK callback)
 	dls_data_send_buffer.buffer = ACDB_MALLOC(uint8_t, dls_data_send_buffer.buffer_size);
 
 	ats_dls_tcpip_send_callback = callback;
+
+	//start ready buffer thread
+	ats_dls_create_ready_buffer_thread();
 destroy_lock:
 	if(AR_FAILED(status))
+	{
+		ar_osal_thread_join_destroy(thd_ready_buffer_routine);
 		ar_osal_mutex_destroy(buffer_ready_lock);
+	}
 
 	return status;
 }
@@ -406,6 +450,8 @@ int32_t ats_dls_deinit(void)
 
 	ar_osal_mutex_destroy(buffer_ready_lock);
 
+	thd_ready_buffer_routine_active = false;
+	ar_osal_thread_join_destroy(thd_ready_buffer_routine);
 	//free ats dls send buffer
 
 	return status;

--- a/gsl/dls_client_api/gsl_dls_client_intf.h
+++ b/gsl/dls_client_api/gsl_dls_client_intf.h
@@ -117,6 +117,13 @@ void gsl_dls_client_get_ready_dls_buffer_list(struct gsl_dls_ready_buffer_index_
 int32_t gsl_dls_client_get_log_buffer(uint32_t log_buffer_index, struct gls_dls_buffer_t* dls_log_buffer);
 
 /**
+ * \brief Stores used log buffers in gsl dsl client context
+ *
+ * \param[in] buffer_index_list: list of buffers to be stored
+ */
+void gsl_dls_client_set_used_buffers(struct gsl_dls_ready_buffer_index_list_t *buffer_index_list);
+
+/**
  * \brief Returns used DLS buffers back to SPF
  *
  * \param[out] buffer_index_list: the list of buffers to return to DLS on SPF

--- a/gsl/inc/gsl_dls_client.h
+++ b/gsl/inc/gsl_dls_client.h
@@ -63,6 +63,14 @@ struct gsl_dls_client_ctxt
      * lock used in conjuction with above signal
      */
     ar_osal_mutex_t sig_lock;
+    /**
+     * for signaling when to return used buffers to spf
+     */
+    struct gsl_signal ready_buffer_sig;
+    /**
+     * List of used buffers to send to spf
+     */
+    struct gsl_dls_ready_buffer_index_list_t used_buffers;
 };
 
 #ifdef __cplusplus

--- a/gsl/src/gsl_dls_client.c
+++ b/gsl/src/gsl_dls_client.c
@@ -27,6 +27,9 @@
 #include "dls_log_pkt_hdr_api.h"
 #include "gsl_msg_builder.h"
 #include "gsl_dls_client.h"
+#include "gsl_mdf_utils.h"
+#include "gsl_common.h"
+#include "ar_osal_sys_id.h"
 
 /*dls client context structure */
 struct gsl_dls_client_ctxt dls_client_ctxt;
@@ -40,6 +43,26 @@ int32_t gsl_dls_client_is_feature_supported()
 #endif
 }
 
+static int32_t gsl_dls_client_alloc_dls_msg(uint32_t apm_cmd, uint32_t apm_hdr_size,
+                                            uint32_t event_param_data_size, gsl_msg_t *msg) {
+    int32_t rc = AR_EOK;
+
+    //Will need to update if DLS is enabled for another master proc ID
+    if (gsl_mdf_utils_is_master_proc(GSL_GET_SPF_SS_MASK(AR_AUDIO_DSP))) {
+        rc = gsl_msg_alloc(apm_cmd, GSL_DLS_CLIENT_GPR_SRC_PORT, DLS_MODULE_INSTANCE_ID,
+          apm_hdr_size, 0, GPR_IDS_DOMAIN_ID_ADSP_V, event_param_data_size, true, msg);
+        if (AR_FAILED(rc))
+            GSL_ERR("failed to allocate gsl msg for ADSP | status %d", rc);
+    } else {
+        rc = gsl_msg_alloc(apm_cmd, GSL_DLS_CLIENT_GPR_SRC_PORT, DLS_MODULE_INSTANCE_ID,
+          apm_hdr_size, 0, GPR_IDS_DOMAIN_ID_APPS_V, event_param_data_size, false, msg);
+        if (AR_FAILED(rc))
+            GSL_ERR("failed to allocate gsl msg for APPS | status %d", rc);
+    }
+
+    return rc;
+}
+
 static int32_t gsl_dls_client_register_deregister_commit_log_buffer_event(enum gsl_dls_commit_log_buffer_register_enum_t event_register_flag)
 {
     int32_t rc = AR_EOK;
@@ -47,15 +70,14 @@ static int32_t gsl_dls_client_register_deregister_commit_log_buffer_event(enum g
     apm_cmd_header_t *apm_hdr;
     apm_module_register_events_t *event_payload;
     uint32_t event_param_data_size = GSL_ALIGN_8BYTE(sizeof(apm_module_register_events_t));
-
     /* Register to APM_MODULE_EVENTS*/
 
     gsl_memset(&gsl_msg, 0, sizeof(gsl_msg_t));
 
-	rc = gsl_msg_alloc(APM_CMD_REGISTER_MODULE_EVENTS, GSL_DLS_CLIENT_GPR_SRC_PORT, DLS_MODULE_INSTANCE_ID,
-		sizeof(*apm_hdr), 0, GPR_IDS_DOMAIN_ID_APPS_V, event_param_data_size, false, &gsl_msg);
+    rc = gsl_dls_client_alloc_dls_msg(APM_CMD_REGISTER_MODULE_EVENTS, sizeof(*apm_hdr),
+                                      event_param_data_size, &gsl_msg);
 	if (AR_FAILED(rc)) {
-		GSL_ERR("failed to allocate gsl msg. status %d", rc);
+		GSL_ERR("failed to allocate dls msg | status %d", rc);
 		goto exit;
 	}
 
@@ -109,10 +131,10 @@ int32_t gsl_dls_client_alloc_shmem_and_config_dls_buffer()
 
     gsl_memset(&gsl_msg, 0, sizeof(gsl_msg_t));
 
-	rc = gsl_msg_alloc(APM_CMD_SET_CFG, GSL_DLS_CLIENT_GPR_SRC_PORT, DLS_MODULE_INSTANCE_ID,
-		sizeof(*apm_hdr), 0, GPR_IDS_DOMAIN_ID_APPS_V, dls_config_buffer_param_data_size, false, &gsl_msg);
+    rc = gsl_dls_client_alloc_dls_msg(APM_CMD_SET_CFG, sizeof(*apm_hdr),
+                                      dls_config_buffer_param_data_size, &gsl_msg);
 	if (AR_FAILED(rc)) {
-		GSL_ERR("failed to allocate GSL msg. status %d", rc);
+		GSL_ERR("failed to allocate dls msg | status %d", rc);
 		goto exit;
 	}
 
@@ -238,10 +260,18 @@ int32_t gsl_dls_client_get_log_buffer(uint32_t log_buffer_index, struct gls_dls_
     dls_shmem_buffer_pool = (uint8_t *)dls_client_ctxt.dls_shmem.v_addr + dls_buffer_offset;
     dls_buffer_ptr = (dls_buf_hdr_t *)(dls_shmem_buffer_pool);
 
+    /* Skip the dls buffer header before sending it to the client since its not required by the client */
     dls_log_buffer->size = dls_buffer_ptr->buf_size - sizeof(dls_buf_hdr_t);
     dls_log_buffer->buffer = dls_shmem_buffer_pool + sizeof(dls_buf_hdr_t);
 
     return rc;
+}
+
+void gsl_dls_client_set_used_buffers(struct gsl_dls_ready_buffer_index_list_t *buffer_index_list)
+{
+    //Store used buffers in gsl dsl client context
+    gsl_memcpy(&dls_client_ctxt.used_buffers, sizeof(dls_client_ctxt.used_buffers), buffer_index_list,
+                sizeof(dls_client_ctxt.used_buffers));
 }
 
 int32_t gsl_dls_client_return_used_buffers(struct gsl_dls_ready_buffer_index_list_t *buffer_index_list)
@@ -251,15 +281,27 @@ int32_t gsl_dls_client_return_used_buffers(struct gsl_dls_ready_buffer_index_lis
     gsl_msg_t gsl_msg;
     dls_data_cmd_buffer_return_t *dls_buf_ret_cfg;
     uint32_t dls_buffer_offset = 0;
-    uint32_t dls_buf_ret_cfg_size = GSL_ALIGN_8BYTE(sizeof(uint32_t)
-                                                    + (buffer_index_list->buffer_count * sizeof(dls_buf_start_addr_t)));
+    uint32_t signal_flags = 0;
+    uint32_t dls_buf_ret_cfg_size = 0;
 
-    rc = gsl_msg_alloc(DLS_DATA_CMD_BUFFER_RETURN, GSL_DLS_CLIENT_GPR_SRC_PORT, DLS_MODULE_INSTANCE_ID,
-		sizeof(*apm_hdr), 0, GPR_IDS_DOMAIN_ID_APPS_V, dls_buf_ret_cfg_size, false, &gsl_msg);
-	if (AR_FAILED(rc)) {
-		GSL_ERR("unable to allocate gsl msg for dls buffer return command. status %d", rc);
-		goto exit;
-	}
+    rc = gsl_signal_timedwait(&dls_client_ctxt.ready_buffer_sig, GSL_SPF_TIMEOUT_MS,
+        &signal_flags, NULL, NULL);
+    if (rc) {
+        GSL_ERR("ready buffer signal wait failed | status %d", rc);
+        return rc;
+    }
+
+    buffer_index_list = &dls_client_ctxt.used_buffers;
+
+    dls_buf_ret_cfg_size =  GSL_ALIGN_8BYTE(sizeof(uint32_t)
+                            + (buffer_index_list->buffer_count * sizeof(dls_buf_start_addr_t)));
+
+    rc = gsl_dls_client_alloc_dls_msg(DLS_DATA_CMD_BUFFER_RETURN, sizeof(*apm_hdr),
+                                      dls_buf_ret_cfg_size, &gsl_msg);
+    if (AR_FAILED(rc)) {
+        GSL_ERR("failed to allocate dls msg for buffer return command | status %d", rc);
+        goto exit;
+    }
 
     dls_buf_ret_cfg = GPR_PKT_GET_PAYLOAD(dls_data_cmd_buffer_return_t, gsl_msg.gpr_packet);
     dls_buf_ret_cfg->num_bufs = (uint32_t)buffer_index_list->buffer_count;
@@ -272,7 +314,7 @@ int32_t gsl_dls_client_return_used_buffers(struct gsl_dls_ready_buffer_index_lis
     }
 
 	rc = gsl_send_spf_cmd_wait_for_basic_rsp(&gsl_msg.gpr_packet,
-		&dls_client_ctxt.sig);
+	        &dls_client_ctxt.sig);
     if (AR_FAILED(rc)) {
         GSL_ERR("failed to return %d buffers to dls. status %d", dls_buf_ret_cfg->num_bufs, rc);
     }
@@ -300,12 +342,12 @@ int32_t gsl_dls_client_register_deregister_log_code(uint32_t log_code, bool_t is
 
     gsl_memset(&gsl_msg, 0, sizeof(gsl_msg_t));
 
-	rc = gsl_msg_alloc(APM_CMD_SET_CFG, GSL_DLS_CLIENT_GPR_SRC_PORT, DLS_MODULE_INSTANCE_ID,
-		sizeof(*apm_hdr), 0, GPR_IDS_DOMAIN_ID_APPS_V, dls_log_code_cfg_size, false, &gsl_msg);
-	if (AR_FAILED(rc)) {
-		GSL_ERR("unable to allocate gsl msg for register/deregister log code. status %d", rc);
-		goto exit;
-	}
+    rc = gsl_dls_client_alloc_dls_msg(APM_CMD_SET_CFG, sizeof(*apm_hdr),
+                                      dls_log_code_cfg_size, &gsl_msg);
+    if (AR_FAILED(rc)) {
+        GSL_ERR("failed to allocate dls msg | status %d", rc);
+        goto exit;
+    }
 
 	apm_hdr = GPR_PKT_GET_PAYLOAD(struct apm_cmd_header_t, gsl_msg.gpr_packet);
 	apm_hdr->mem_map_handle = gsl_msg.shmem.spf_mmap_handle;
@@ -326,7 +368,6 @@ int32_t gsl_dls_client_register_deregister_log_code(uint32_t log_code, bool_t is
     for (int i = 0; i < num_log_codes; i++) {
         param_payload->log_codes[i] = log_code;
     }
-
 	GSL_LOG_PKT("send_pkt", GSL_DLS_CLIENT_GPR_SRC_PORT, gsl_msg.gpr_packet,
 		sizeof(*gsl_msg.gpr_packet) + sizeof(*apm_hdr), gsl_msg.payload,
 		apm_hdr->payload_size);
@@ -386,9 +427,9 @@ static uint32_t gsl_dls_client_event_callback(gpr_packet_t *packet, void *callba
             GSL_DBG(
                 "recieved dls commit event: opcode(0x%x) event(0x%x) ",
                 packet->opcode, apm_event->event_id);
-
             dls_client_ctxt.buffer_ready_callback();
             __gpr_cmd_free(packet);
+            gsl_signal_set(&dls_client_ctxt.ready_buffer_sig, 0, 0, NULL);
         }
         break;
     }
@@ -412,6 +453,13 @@ int32_t gsl_dls_client_init(struct gsl_dls_buffer_pool_config_t *buffer_pool_con
     if (rc) {
         GSL_ERR("unable to create signal for dls events. status %d", rc);
         __gpr_cmd_deregister(GSL_DLS_CLIENT_GPR_SRC_PORT);
+        return rc;
+    }
+
+    rc = gsl_signal_create(&dls_client_ctxt.ready_buffer_sig, NULL);
+    GSL_ERR("Created ready buffer signal");
+    if (rc) {
+        GSL_ERR("unable to create signal for ready buffer event | status %d", rc);
         return rc;
     }
 


### PR DESCRIPTION
Create a new thread for DLS that will wait for
available DLS buffers to be sent to ADSP. This
fixes a deadlock issue with DLS for systems using
ADSP as the master process.

CRs-Fixed: 4465474