### PR TITLE
osal: shmem: Fix sys_id type mismatch and handle posix_memalign return value

### DIFF
--- a/ar_osal/src/linux/ar_osal_shmem_virtual.c
+++ b/ar_osal/src/linux/ar_osal_shmem_virtual.c
@@ -135,7 +135,11 @@ int32_t ar_shmem_alloc(_Inout_ ar_shmem_info *info)
     info->mem_type = AR_SHMEM_VIRTUAL_MEMORY;
 
 
-    posix_memalign(&p, SHMEM_4K_ALIGNMENT,info->buf_size);
+    if (0 != posix_memalign(&p, SHMEM_4K_ALIGNMENT, info->buf_size)) {
+        AR_LOG_ERR(AR_OSAL_SHMEM_LOG_TAG, "Error: posix_memalign failed");
+        status = AR_ENOMEMORY;
+        goto end;
+    }
     info->vaddr = p;
     AR_LOG_ERR(AR_OSAL_SHMEM_LOG_TAG, "vaddr(0x%p)", info->vaddr);
     if (NULL == info->vaddr)

--- a/ar_osal/src/linux/ar_osal_shmem_virtual.c
+++ b/ar_osal/src/linux/ar_osal_shmem_virtual.c
@@ -29,7 +29,7 @@
  *  Nonzero -- Failure
  */
 _IRQL_requires_max_(PASSIVE_LEVEL)
-int32_t ar_shmem_validate_sys_id(_In_ uint8_t num_sys_id, _In_ uint8_t *sys_id)
+int32_t ar_shmem_validate_sys_id(_In_ uint8_t num_sys_id, _In_ ar_shmem_proc_info *sys_id)
 {
     PAGED_FUNCTION();
     int32_t status = AR_EOK;
@@ -41,12 +41,12 @@ int32_t ar_shmem_validate_sys_id(_In_ uint8_t num_sys_id, _In_ uint8_t *sys_id)
 
     for (uint8_t i = 0; i < num_sys_id; i++)
     {
-        if (AR_AUDIO_DSP != sys_id[i] &&
-            AR_MODEM_DSP != sys_id[i] &&
-            AR_SENSOR_DSP != sys_id[i] &&
-            AR_COMPUTE_DSP != sys_id[i] &&
-            AR_APSS != sys_id[i] &&
-            AR_APSS2 != sys_id[i])
+        if (AR_AUDIO_DSP != sys_id[i].proc_id &&
+            AR_MODEM_DSP != sys_id[i].proc_id &&
+            AR_SENSOR_DSP != sys_id[i].proc_id &&
+            AR_COMPUTE_DSP != sys_id[i].proc_id &&
+            AR_APSS != sys_id[i].proc_id &&
+            AR_APSS2 != sys_id[i].proc_id)
         {
             status = AR_EBADPARAM;
             break;

--- a/ar_osal/src/linux/qcom/ar_osal_shmem_ap.c
+++ b/ar_osal/src/linux/qcom/ar_osal_shmem_ap.c
@@ -86,7 +86,11 @@ int32_t ar_shmem_ap_alloc(_Inout_ ar_shmem_info *info)
    info->pa_msw     = 0;
    info->index_type = AR_SHMEM_BUFFER_ADDRESS;
    info->mem_type   = AR_SHMEM_VIRTUAL_MEMORY;
-   posix_memalign(&p, SHMEM_4K_ALIGNMENT, info->buf_size);
+   if (0 != posix_memalign(&p, SHMEM_4K_ALIGNMENT, info->buf_size)) {
+      AR_LOG_ERR(AR_OSAL_SHMEM_LOG_TAG, "Error: posix_memalign failed");
+      status = AR_ENOMEMORY;
+      goto end;
+   }
    info->vaddr = p;
    AR_LOG_ERR(AR_OSAL_SHMEM_LOG_TAG, "vaddr(0x%p)", info->vaddr);
    if (NULL == info->vaddr)

--- a/ar_osal/src/linux/qcom/ar_osal_shmem_ion.c
+++ b/ar_osal/src/linux/qcom/ar_osal_shmem_ion.c
@@ -73,7 +73,7 @@ static pthread_mutex_t ar_shmem_lock = PTHREAD_MUTEX_INITIALIZER;
 *  0 -- Success
 *  Nonzero -- Failure
 */
-int32_t ar_shmem_validate_sys_id(uint8_t num_sys_id, uint8_t *sys_id)
+int32_t ar_shmem_validate_sys_id(uint8_t num_sys_id, ar_shmem_proc_info *sys_id)
 {
     int32_t status = AR_EOK;
     if (0 == num_sys_id || NULL == sys_id)
@@ -84,12 +84,12 @@ int32_t ar_shmem_validate_sys_id(uint8_t num_sys_id, uint8_t *sys_id)
 
     for (uint8_t i = 0; i < num_sys_id; i++)
     {
-        if (AR_AUDIO_DSP != sys_id[i] &&
-            AR_MODEM_DSP != sys_id[i] &&
-            AR_SENSOR_DSP != sys_id[i] &&
-            AR_COMPUTE_DSP != sys_id[i] &&
-            AR_APSS != sys_id[i] &&
-            AR_APSS2 != sys_id[i])
+        if (AR_AUDIO_DSP != sys_id[i].proc_id &&
+            AR_MODEM_DSP != sys_id[i].proc_id &&
+            AR_SENSOR_DSP != sys_id[i].proc_id &&
+            AR_COMPUTE_DSP != sys_id[i].proc_id &&
+            AR_APSS != sys_id[i].proc_id &&
+            AR_APSS2 != sys_id[i].proc_id)
         {
             status = AR_EBADPARAM;
             break;


### PR DESCRIPTION
ar_shmem_info_t.sys_id changed from uint8_t * to ar_shmem_proc_info * but ar_shmem_validate_sys_id() was not updated, causing an incompatible pointer type error under -Werror with linux-yocto 6.18. Update the parameter type and access proc_id in the validation loop.

posix_memalign() carries \_\_attribute\_\_((warn_unused_result)); ignoring it triggers -Wunused-result, promoted to an error by -Werror. On failure the output pointer is left indeterminate, making the subsequent NULL check on vaddr unreliable. Check the return value and propagate AR_ENOMEMORY on failure.

CRs-Fixed: 4550887