### PR TITLE
aml: Fix underflow crash caused by empty Delta files

### DIFF
--- a/acdb/src/acdb_delta_file_mgr.c
+++ b/acdb/src/acdb_delta_file_mgr.c
@@ -305,20 +305,36 @@ int32_t AcdbDeltaDataCmdSave(void)
         return AR_EOK;
     }
 
+    /* Check if heap contains any data. If not, do nothing and return */
+	p_map_list = &map_list;
+
+	status = acdb_heap_ioctl(ACDB_HEAP_CMD_GET_MAP_LIST, NULL, 0,
+        (uint8_t*)&p_map_list, sizeof(LinkedList));
+	if (AR_EOK != status) goto end;
+
+	cur_node = p_map_list->p_head;
+
+    if(cur_node == NULL)
+    {
+        ACDB_ERR("Warning[%d]: No data to write. The heap is empty",
+            AR_EHANDLE);
+        status = AR_EOK;
+        goto end;
+    }
+
     db_info = (AcdbDeltaFileManDatabaseInfo*)
         context_handle->delta_manager_handle;
 
     fhandle = &db_info->file_handle;
 
-	//Close and delete old delta file
+	/* Close and delete old delta file */
 	ar_fclose(*fhandle);
 
     status = ar_fdelete(db_info->delta_file_path.path);
-
     if (AR_FAILED(status))
     {
         ACDB_ERR("Error[%d]: Failed to delete delta file", status);
-        return status;
+        goto end;
     }
 
 	/* Create new delta file and set ar_fhandle to acdb_delta_file_man_context
@@ -332,7 +348,7 @@ int32_t AcdbDeltaDataCmdSave(void)
     if (AR_FAILED(status))
 	{
 		ACDB_ERR_MSG_1("Unable to create a new delta acdb file", status);
-        return status;
+        goto end;
 	}
 
     fsize = delta_info.properties.file_size;
@@ -342,25 +358,20 @@ int32_t AcdbDeltaDataCmdSave(void)
     if (AR_FAILED(status))
     {
         ACDB_ERR("Error[%d]: Failed to open delta file", status);
-        return status;
+        goto end;
     }
 
 	db_info->file_handle = *fhandle;
 
+    /* Write the header first as a place holder. We'll update this after 
+     * determining the number of maps and size of the data */
 	status = acdb_delta_parser_write_file_header(
 		db_info->file_handle,
 		&db_info->file_info, 0, 0);
 
     if (AR_FAILED(status)) goto end;
 
-	p_map_list = &map_list;
-
-	status = acdb_heap_ioctl(ACDB_HEAP_CMD_GET_MAP_LIST, NULL, 0,
-        (uint8_t*)&p_map_list, sizeof(LinkedList));
-	if (AR_EOK != status) goto end;
-
-	cur_node = p_map_list->p_head;
-
+    /* Write the map data to the file */
 	while (cur_node != NULL)
 	{
         map = ((acdb_delta_data_map_t*)cur_node->p_struct);
@@ -369,6 +380,7 @@ int32_t AcdbDeltaDataCmdSave(void)
 		cur_node = cur_node->p_next;
 	}
 
+    /* Seek back to the begining of the file to update the header */
 	status = ar_fseek(*fhandle, 0, AR_FSEEK_BEGIN);
     if (AR_FAILED(status))
     {
@@ -391,7 +403,6 @@ int32_t AcdbDeltaDataCmdSave(void)
 end:
     AcdbListClear(p_map_list);
     p_map_list = NULL;
-    ar_fclose(*fhandle);
 
 	return status;
 }

--- a/acdb/src/acdb_delta_parser.c
+++ b/acdb/src/acdb_delta_parser.c
@@ -128,13 +128,24 @@ int32_t acdb_delta_parser_is_file_valid(
 		return ACDB_PARSE_INVALID_FILE;
 	}
 
-	if (file_size != file_header.file_data_size
-        + (sizeof(AcdbDeltaFileHeader) - sizeof(uint32_t)))
+	/* File data size should be at least 4 bytes (for the map count) for an empty delta file */
+	if(file_header.file_data_size == 0)
 	{
-		ACDB_ERR("Error[%d]: The delta file data section size %d is incorrect."
-            " It should be %d bytes",
+		ACDB_ERR("Error[%d]: The delta file data size of %d bytes is incorrect."
+            " It should be %d bytes for an empty file",
+			AR_EFAILED,
             file_header.file_data_size,
-            file_size - sizeof(AcdbDeltaFileHeader) - sizeof(uint32_t));
+            sizeof(uint32_t));//map_count
+		return ACDB_PARSE_INVALID_FILE;
+	}
+	else if (file_header.file_data_size > sizeof(uint32_t) && 
+			file_size != file_header.file_data_size + (sizeof(AcdbDeltaFileHeader) - sizeof(uint32_t)))
+	{
+		ACDB_ERR("Error[%d]: The delta file data size of %d is incorrect."
+            " It should be %d bytes",
+			AR_EFAILED,
+            file_header.file_data_size,
+            file_size - (sizeof(AcdbDeltaFileHeader) - sizeof(uint32_t)));
 		return ACDB_PARSE_INVALID_FILE;
 	}
 


### PR DESCRIPTION
Fix underflow crash caused by empty Delta files only containing a header with no data and the data size field being set to 0 bytes. It should be 4 bytes if the delta file has no data. The 4 bytes represent the map_count field that comes after the main header.

CRs-Fixed: 4535670