### PR TITLE
ar_osal/linux: Fix msm_audio.h not found in ar_osal_shmem_phy.c

### DIFF
--- a/ar_osal/src/linux/ar_osal_shmem_phy.c
+++ b/ar_osal/src/linux/ar_osal_shmem_phy.c
@@ -20,7 +20,7 @@
 #include <sys/ioctl.h>
 #include <linux/dma-buf.h>
 #include <linux/dma-heap.h>
-#include "msm_audio.h"
+#include <linux/msm_audio.h>
 #include "ar_osal_shmem.h"
 #include "ar_osal_error.h"
 #include "ar_osal_log.h"

--- a/ar_osal/src/linux/ar_osal_shmem_phy.c
+++ b/ar_osal/src/linux/ar_osal_shmem_phy.c
@@ -269,6 +269,22 @@ int32_t ar_shmem_init(void)
     return status;
 }
 
+/**
+ * \brief Initialize the shared memory interface using a list of processor
+ *        domains (V2 API).
+ *
+ * \param[in] num_master_procs   Number of processor domain IDs.
+ * \param[in] master_procs       Pointer to an array of processor domain IDs.
+ *
+ * \return
+ *  0        -- Success
+ *  Nonzero  -- Failure
+ */
+int32_t ar_shmem_init_v2(uint32_t num_master_procs, uint32_t *master_procs)
+{
+    return AR_EOK;
+}
+
 /*
  * \brief Allocates shared memory.
  *  Only non cached memory allocation supported.


### PR DESCRIPTION
1. When building with audio DMA support and --without-qcom configuration the compiler cannot locate msm_audio.h via the local include path.
The header is part of the kernel uapi headers available part of system include. Replace the local include path with <linux/msm_audio.h> to fix the file-not-found build error.

2. Resolve an undefined reference to ar_shmem_init_v2 when linking audioreach-graphmgr against libar-gsl.so. The V2 symbol is declared in the public OSAL header and called by GSL, but is not defined in physical shmem implementation (ar_osal_shmem_phy.c).

CRs-Fixed: 4605897
